### PR TITLE
Fix Compiliation on MacOS

### DIFF
--- a/src/notifier.rs
+++ b/src/notifier.rs
@@ -45,8 +45,7 @@ impl Notifier {
 
     // If we're on a mac
     #[cfg(target_os = "macos")]
-    pub fn open_in_browser(&self) -> Result<(), NotifyError> {
-        let url = self.get_url()?;
+    pub fn open_in_browser(&self, url: &str) -> Result<(), NotifyError> {
         self.run_command("open", &[url])
     }
 


### PR DESCRIPTION
Updated method `open_in_browser` to take in a url, similar to what the other platforms do, since self does not contain a method called `get_url()`.